### PR TITLE
Add PEP 561-style py.typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ classifiers = [
     'Topic :: Software Development :: Libraries :: Application Frameworks',
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
+packages = [
+    { include = "asgi_correlation_id" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asgi-correlation-id"
-version = "1.1.0"
+version = "1.1.1"
 description = "Middleware correlating project logs to individual requests"
 authors = ["Sondre Lillebø Gundersen <sondrelg@live.no>"]
 maintainers = ["Jonas Krüger Svensson <jonas-ks@hotmail.com>"]


### PR DESCRIPTION
Add `py.typed` to support type checking of the package.