### PR TITLE
fix: Simplify header logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asgi-correlation-id"
-version = "1.1.3"
+version = "1.1.4"
 description = "Middleware correlating project logs to individual requests"
 authors = ["Sondre Lillebø Gundersen <sondrelg@live.no>"]
 maintainers = ["Jonas Krüger Svensson <jonas-ks@hotmail.com>"]


### PR DESCRIPTION
Resolves #29 

#25 seems to have introduced a bug. Looking over the starlette `Headers` docs, it seems we're making life harder for ourselves than we need to. Using `MutableHeaders` rids us of all explicit type casting.