### PR TITLE
Make middleware fully configurable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,13 +40,13 @@ repos:
         ]
 
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.14.3
+    rev: 0.15.0
     hooks:
       - id: check-github-actions
       - id: check-github-workflows
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
+    rev: v2.32.1
     hooks:
       - id: pyupgrade
         args: [ "--py36-plus" ]

--- a/asgi_correlation_id/middleware.py
+++ b/asgi_correlation_id/middleware.py
@@ -24,6 +24,9 @@ def is_valid_uuid4(uuid_: str) -> bool:
         return False
 
 
+FAILED_VALIDATION_MESSAGE = 'Generated new request ID (%s), since request header value failed validation'
+
+
 @dataclass
 class CorrelationIdMiddleware:
     app: 'ASGIApp'
@@ -54,8 +57,8 @@ class CorrelationIdMiddleware:
             id_value = self.generator()
         elif self.validator and not self.validator(header_value):
             # Also generate a request ID if one was found, but it was deemed invalid
-            logger.warning('Generating new request ID, since header value \'%s\' is invalid', header_value)
             id_value = self.generator()
+            logger.warning(FAILED_VALIDATION_MESSAGE, header_value)
         else:
             # Otherwise, use the found request ID
             id_value = header_value

--- a/asgi_correlation_id/middleware.py
+++ b/asgi_correlation_id/middleware.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger('asgi_correlation_id')
 
 
-def is_valid_uuid(uuid_: str) -> bool:
+def is_valid_uuid4(uuid_: str) -> bool:
     """
     Check whether a string is a valid v4 uuid.
     """
@@ -42,7 +42,7 @@ class CorrelationIdMiddleware:
 
         if not header_value:
             id_value = uuid4().hex
-        elif self.validate_header_as_uuid and not is_valid_uuid(header_value):
+        elif self.validate_header_as_uuid and not is_valid_uuid4(header_value):
             logger.warning('Generating new UUID, since header value \'%s\' is invalid', header_value)
             id_value = uuid4().hex
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ build-backend = "poetry.masonry.api"
 quiet = true
 line-length = 120
 skip-string-normalization = true
-experimental-string-processing = true
+preview = true
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "asgi-correlation-id"
-version = "2.0.0"
+version = "3.0.0a1"
 description = "Middleware correlating project logs to individual requests"
 authors = ["Sondre Lillebø Gundersen <sondrelg@live.no>"]
 maintainers = ["Jonas Krüger Svensson <jonas-ks@hotmail.com>"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [tool:pytest]
 testpaths = tests
+asyncio_mode = auto
 
 [flake8]
 max-line-length = 120

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ def _configure_logging():
     }
     dictConfig(LOGGING)
 
+
 TRANSFORMER_VALUE = 'some-id'
 
 default_app = FastAPI(middleware=[Middleware(CorrelationIdMiddleware)])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,8 +43,14 @@ def _configure_logging():
     }
     dictConfig(LOGGING)
 
+TRANSFORMER_VALUE = 'some-id'
 
-app = FastAPI(middleware=[Middleware(CorrelationIdMiddleware)])
+default_app = FastAPI(middleware=[Middleware(CorrelationIdMiddleware)])
+no_validator_or_transformer_app = FastAPI(
+    middleware=[Middleware(CorrelationIdMiddleware, validator=None, transformer=None)]
+)
+transformer_app = FastAPI(middleware=[Middleware(CorrelationIdMiddleware, transformer=lambda a: a * 2)])
+generator_app = FastAPI(middleware=[Middleware(CorrelationIdMiddleware, generator=lambda: TRANSFORMER_VALUE)])
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -56,5 +62,5 @@ def event_loop():
 
 @pytest.fixture(scope='module')
 async def client() -> AsyncClient:
-    async with AsyncClient(app=app, base_url='http://test') as client:
+    async with AsyncClient(app=default_app, base_url='http://test') as client:
         yield client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import asyncio
 from logging.config import dictConfig
 
 import pytest
+import pytest_asyncio
 from fastapi import FastAPI
 from httpx import AsyncClient
 from starlette.middleware import Middleware
@@ -61,7 +62,7 @@ def event_loop():
     loop.close()
 
 
-@pytest.fixture(scope='module')
+@pytest_asyncio.fixture(scope='module')
 async def client() -> AsyncClient:
     async with AsyncClient(app=default_app, base_url='http://test') as client:
         yield client

--- a/tests/test_extension_celery.py
+++ b/tests/test_extension_celery.py
@@ -5,7 +5,7 @@ import pytest
 from celery import shared_task
 
 from asgi_correlation_id.extensions.celery import load_celery_current_and_parent_ids, load_correlation_ids
-from tests.conftest import app
+from tests.conftest import default_app
 
 logger = logging.getLogger('asgi_correlation_id')
 
@@ -40,7 +40,7 @@ async def test_endpoint_to_worker_to_worker(client, caplog, celery_session_app, 
         - The current ID of the first worker to be added as the parent ID of the second worker
     """
 
-    @app.get('/celery-test', status_code=200)
+    @default_app.get('/celery-test', status_code=200)
     async def test_view() -> dict:
         logger.debug('Test view')
         task1.delay().get(timeout=10)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -4,53 +4,52 @@ from uuid import uuid4
 
 import pytest
 from fastapi import Response
+from httpx import AsyncClient
 from starlette.testclient import TestClient
 
-from tests.conftest import app
+from tests.conftest import default_app, generator_app, no_validator_or_transformer_app, transformer_app, \
+    TRANSFORMER_VALUE
 
 if TYPE_CHECKING:
     from starlette.websockets import WebSocket
 
 logger = logging.getLogger('asgi_correlation_id')
 
+apps = [default_app, no_validator_or_transformer_app, transformer_app, generator_app]
+
 pytestmark = pytest.mark.asyncio
 
 
-@app.get('/test', status_code=200)
-async def test_view() -> dict:
-    logger.debug('Test view')
-    return {'test': 'test'}
-
-
-@app.websocket_route('/ws')
-async def websocket(websocket: 'WebSocket'):
-    await websocket.accept()
-    await websocket.send_json({'msg': 'Hello WebSocket'})
-    await websocket.close()
-
-
-async def test_returned_response_headers(client):
+@pytest.mark.parametrize('app', [default_app, no_validator_or_transformer_app, generator_app])
+async def test_returned_response_headers(app):
     """
     We expect:
      - our request id header to be returned back to us
      - the request id header name to be returned in access-control-expose-headers
     """
-    # Check we get the right headers back
-    correlation_id = uuid4().hex
-    response = await client.get('test', headers={'X-Request-ID': correlation_id})
-    assert response.headers['access-control-expose-headers'] == 'X-Request-ID'
-    assert response.headers['X-Request-ID'] == correlation_id
 
-    # And do it one more time, jic
-    second_correlation_id = uuid4().hex
-    second_response = await client.get('test', headers={'X-Request-ID': second_correlation_id})
-    assert second_response.headers['access-control-expose-headers'] == 'X-Request-ID'
-    assert second_response.headers['X-Request-ID'] == second_correlation_id
+    @app.get('/test', status_code=200)
+    async def test_view() -> dict:
+        logger.debug('Test view')
+        return {'test': 'test'}
 
-    # Then try without specifying a request id
-    third_response = await client.get('test')
-    assert third_response.headers['access-control-expose-headers'] == 'X-Request-ID'
-    assert third_response.headers['X-Request-ID'] not in [correlation_id, second_correlation_id]
+    async with AsyncClient(app=app, base_url='http://test') as client:
+        # Check we get the right headers back
+        correlation_id = uuid4().hex
+        response = await client.get('test', headers={'X-Request-ID': correlation_id})
+        assert response.headers['access-control-expose-headers'] == 'X-Request-ID'
+        assert response.headers['X-Request-ID'] == correlation_id
+
+        # And do it one more time, jic
+        second_correlation_id = uuid4().hex
+        second_response = await client.get('test', headers={'X-Request-ID': second_correlation_id})
+        assert second_response.headers['access-control-expose-headers'] == 'X-Request-ID'
+        assert second_response.headers['X-Request-ID'] == second_correlation_id
+
+        # Then try without specifying a request id
+        third_response = await client.get('test')
+        assert third_response.headers['access-control-expose-headers'] == 'X-Request-ID'
+        assert third_response.headers['X-Request-ID'] not in [correlation_id, second_correlation_id]
 
 
 bad_uuids = [
@@ -62,55 +61,89 @@ bad_uuids = [
 
 
 @pytest.mark.parametrize('value', bad_uuids)
-async def test_non_uuid_header(client, caplog, value):
+@pytest.mark.parametrize('app', [default_app, transformer_app, generator_app])
+async def test_non_uuid_header(client, caplog, value, app):
     """
     We expect the middleware to ignore our request ID and log a warning
     when the request ID we pass doesn't correspond to the uuid4 format.
     """
-    response = await client.get('test', headers={'X-Request-ID': value})
-    assert response.headers['X-Request-ID'] != value
-    assert caplog.messages[0] == f"Generating new UUID, since header value '{value}' is invalid"
+    @app.get('/test', status_code=200)
+    async def test_view() -> dict:
+        logger.debug('Test view')
+        return {'test': 'test'}
+
+    async with AsyncClient(app=app, base_url='http://test') as client:
+        response = await client.get('test', headers={'X-Request-ID': value})
+        assert response.headers['X-Request-ID'] != value
+        assert caplog.messages[0] == f"Generating new request ID, since header value '{value}' is invalid"
 
 
-async def test_websocket_request(caplog):
+@pytest.mark.parametrize('app', apps)
+async def test_websocket_request(caplog, app):
     """
     We expect websocket requests to not be handled.
-
     This test could use improvement.
     """
+
+    @app.websocket_route('/ws')
+    async def websocket(websocket: 'WebSocket'):
+        await websocket.accept()
+        await websocket.send_json({'msg': 'Hello WebSocket'})
+        await websocket.close()
+
     client = TestClient(app)
-    with client.websocket_connect('/ws') as websocket:
-        websocket.receive_json()
+    with client.websocket_connect('/ws') as ws:
+        ws.receive_json()
         assert caplog.messages == []
 
 
-@app.get('/access-control-expose-headers')
-async def access_control_view() -> Response:
-    return Response(status_code=204, headers={'Access-Control-Expose-Headers': 'test1, test2'})
-
-
-async def test_access_control_expose_headers(client, caplog):
+@pytest.mark.parametrize('app', apps)
+async def test_access_control_expose_headers(caplog, app):
     """
     The middleware should add the correlation ID header name to exposed headers.
-
     The middleware should not overwrite other values, but should append to it.
     """
-    response = await client.get('access-control-expose-headers')
-    assert response.headers['Access-Control-Expose-Headers'] == 'test1, test2, X-Request-ID'
+    @app.get('/access-control-expose-headers')
+    async def access_control_view() -> Response:
+        return Response(status_code=204, headers={'Access-Control-Expose-Headers': 'test1, test2'})
+
+    async with AsyncClient(app=app, base_url='http://test') as client:
+        response = await client.get('access-control-expose-headers')
+        assert response.headers['Access-Control-Expose-Headers'] == 'test1, test2, X-Request-ID'
 
 
-@app.get('/multiple_headers_same_name')
-async def multiple_headers_response() -> Response:
-    response = Response(status_code=204)
-    response.set_cookie('access_token_cookie', 'test-access-token')
-    response.set_cookie('refresh_token_cookie', 'test-refresh-token')
-    return response
-
-
-async def test_multiple_headers_same_name(client, caplog):
+@pytest.mark.parametrize('app', apps)
+async def test_multiple_headers_same_name(caplog, app):
     """
     The middleware should not change the headers that were set in the response and return all of them as it is.
     """
-    response = await client.get('multiple_headers_same_name')
-    assert response.headers['set-cookie'].find('access_token_cookie') != -1
-    assert response.headers['set-cookie'].find('refresh_token_cookie') != -1
+    @app.get('/multiple_headers_same_name')
+    async def multiple_headers_response() -> Response:
+        response = Response(status_code=204)
+        response.set_cookie('access_token_cookie', 'test-access-token')
+        response.set_cookie('refresh_token_cookie', 'test-refresh-token')
+        return response
+
+    async with AsyncClient(app=app, base_url='http://test') as client:
+        response = await client.get('multiple_headers_same_name')
+        assert response.headers['set-cookie'].find('access_token_cookie') != -1
+        assert response.headers['set-cookie'].find('refresh_token_cookie') != -1
+
+
+async def test_no_validator():
+    async with AsyncClient(app=no_validator_or_transformer_app, base_url='http://test') as client:
+        response = await client.get('test', headers={'X-Request-ID': 'bad-uuid'})
+        assert response.headers['X-Request-ID'] == 'bad-uuid'
+
+
+async def test_custom_transformer():
+    cid = uuid4().hex
+    async with AsyncClient(app=transformer_app, base_url='http://test') as client:
+        response = await client.get('test', headers={'X-Request-ID': cid})
+        assert response.headers['X-Request-ID'] == cid * 2
+
+
+async def test_custom_generator():
+    async with AsyncClient(app=generator_app, base_url='http://test') as client:
+        response = await client.get('test', headers={'X-Request-ID': 'bad-uuid'})
+        assert response.headers['X-Request-ID'] == TRANSFORMER_VALUE

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -7,6 +7,7 @@ from fastapi import Response
 from httpx import AsyncClient
 from starlette.testclient import TestClient
 
+from asgi_correlation_id.middleware import FAILED_VALIDATION_MESSAGE
 from tests.conftest import (
     TRANSFORMER_VALUE,
     default_app,
@@ -81,7 +82,7 @@ async def test_non_uuid_header(client, caplog, value, app):
     async with AsyncClient(app=app, base_url='http://test') as client:
         response = await client.get('test', headers={'X-Request-ID': value})
         assert response.headers['X-Request-ID'] != value
-        assert caplog.messages[0] == f"Generating new request ID, since header value '{value}' is invalid"
+        assert caplog.messages[0] == FAILED_VALIDATION_MESSAGE.replace('%s', value)
 
 
 @pytest.mark.parametrize('app', apps)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -7,8 +7,13 @@ from fastapi import Response
 from httpx import AsyncClient
 from starlette.testclient import TestClient
 
-from tests.conftest import default_app, generator_app, no_validator_or_transformer_app, transformer_app, \
-    TRANSFORMER_VALUE
+from tests.conftest import (
+    TRANSFORMER_VALUE,
+    default_app,
+    generator_app,
+    no_validator_or_transformer_app,
+    transformer_app,
+)
 
 if TYPE_CHECKING:
     from starlette.websockets import WebSocket
@@ -67,6 +72,7 @@ async def test_non_uuid_header(client, caplog, value, app):
     We expect the middleware to ignore our request ID and log a warning
     when the request ID we pass doesn't correspond to the uuid4 format.
     """
+
     @app.get('/test', status_code=200)
     async def test_view() -> dict:
         logger.debug('Test view')
@@ -103,6 +109,7 @@ async def test_access_control_expose_headers(caplog, app):
     The middleware should add the correlation ID header name to exposed headers.
     The middleware should not overwrite other values, but should append to it.
     """
+
     @app.get('/access-control-expose-headers')
     async def access_control_view() -> Response:
         return Response(status_code=204, headers={'Access-Control-Expose-Headers': 'test1, test2'})
@@ -117,6 +124,7 @@ async def test_multiple_headers_same_name(caplog, app):
     """
     The middleware should not change the headers that were set in the response and return all of them as it is.
     """
+
     @app.get('/multiple_headers_same_name')
     async def multiple_headers_response() -> Response:
         response = Response(status_code=204)


### PR DESCRIPTION
This is mostly a reimplementation of #15, motivated by #38. It will require us to bump a major version, since we are removing some backwards compatibility, but I think it's for the best.

In short, the PR replaces the built-in uuid4 generation and validation with concepts of:
- a `generator` function to create new ID values when needed
- a `validator` function to optionally validate incoming header values (and discard failed ones), and
- a `transformer` function to optionally clean header values

