### PR TITLE
ID generator for celery extension

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,4 +68,4 @@ jobs:
         with:
           file: ./coverage.xml
           fail_ci_if_error: true
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.10.6'

--- a/README.md
+++ b/README.md
@@ -484,6 +484,15 @@ load_correlation_ids()
 + load_celery_current_and_parent_ids()
 ```
 
+If you wish to correlate celery task IDs through the IDs found in your broker, use the `use_internal_celery_task_id` argument on `load_celery_current_and_parent_ids`
+```diff
+from asgi_correlation_id.extensions.celery import load_correlation_ids, load_celery_current_and_parent_ids
+
+load_correlation_ids()
++ load_celery_current_and_parent_ids(use_internal_celery_task_id=True)
+```
+Note: `load_celery_current_and_parent_ids` will ignore the `generator` argument when `use_internal_celery_task_id` is set to `True`
+
 To set up the additional log filters, update your log config like this:
 
 ```diff

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ load_correlation_ids()
 + load_celery_current_and_parent_ids()
 ```
 
-If you wish to correlate celery task IDs through the IDs found in your broker, use the `use_internal_celery_task_id` argument on `load_celery_current_and_parent_ids`
+If you wish to correlate celery task IDs through the IDs found in your broker (i.e., the celery `task_id`), use the `use_internal_celery_task_id` argument on `load_celery_current_and_parent_ids`
 ```diff
 from asgi_correlation_id.extensions.celery import load_correlation_ids, load_celery_current_and_parent_ids
 

--- a/asgi_correlation_id/extensions/celery.py
+++ b/asgi_correlation_id/extensions/celery.py
@@ -8,12 +8,10 @@ from asgi_correlation_id.extensions.sentry import get_sentry_extension
 if TYPE_CHECKING:
     from celery import Task
 
-uuid_hex_generator_fn: Callable[[], str] = lambda: uuid4().hex
+uuid_hex_generator: Callable[[], str] = lambda: uuid4().hex
 
 
-def load_correlation_ids(
-    header_key: str = 'CORRELATION_ID', generator: Callable[[], str] = uuid_hex_generator_fn
-) -> None:
+def load_correlation_ids(header_key: str = 'CORRELATION_ID', generator: Callable[[], str] = uuid_hex_generator) -> None:
     """
     Transfer correlation IDs from a HTTP request to a Celery worker,
     when spawned from a request.
@@ -66,7 +64,7 @@ def load_correlation_ids(
 
 def load_celery_current_and_parent_ids(
     header_key: str = 'CELERY_PARENT_ID',
-    generator: Callable[[], str] = uuid_hex_generator_fn,
+    generator: Callable[[], str] = uuid_hex_generator,
     use_internal_celery_task_id: bool = False,
 ) -> None:
     """

--- a/asgi_correlation_id/log_filters.py
+++ b/asgi_correlation_id/log_filters.py
@@ -8,12 +8,7 @@ if TYPE_CHECKING:
 
 
 def _trim_string(string: Optional[str], string_length: Optional[int]) -> Optional[str]:
-    trimmed_string: Optional[str]
-    if string_length is not None and string:
-        trimmed_string = string[:string_length]
-    else:
-        trimmed_string = string
-    return trimmed_string
+    return string[:string_length] if string_length is not None and string else string
 
 
 # Middleware

--- a/asgi_correlation_id/log_filters.py
+++ b/asgi_correlation_id/log_filters.py
@@ -7,6 +7,15 @@ if TYPE_CHECKING:
     from logging import LogRecord
 
 
+def _trim_string(string: Optional[str], string_length: Optional[int]) -> Optional[str]:
+    trimmed_string: Optional[str]
+    if string_length is not None and string:
+        trimmed_string = string[:string_length]
+    else:
+        trimmed_string = string
+    return trimmed_string
+
+
 # Middleware
 
 
@@ -27,10 +36,7 @@ class CorrelationIdFilter(Filter):
         metadata.
         """
         cid = correlation_id.get()
-        if self.uuid_length is not None and cid:
-            record.correlation_id = cid[: self.uuid_length]
-        else:
-            record.correlation_id = cid
+        record.correlation_id = _trim_string(cid, self.uuid_length)
         return True
 
 
@@ -38,7 +44,7 @@ class CorrelationIdFilter(Filter):
 
 
 class CeleryTracingIdsFilter(Filter):
-    def __init__(self, name: str = '', uuid_length: int = 32):
+    def __init__(self, name: str = '', uuid_length: Optional[int] = None):
         super().__init__(name=name)
         self.uuid_length = uuid_length
 
@@ -52,7 +58,7 @@ class CeleryTracingIdsFilter(Filter):
         or from an endpoint, the parent ID will be None.
         """
         pid = celery_parent_id.get()
-        record.celery_parent_id = pid[: self.uuid_length] if pid else pid
+        record.celery_parent_id = _trim_string(pid, self.uuid_length)
         cid = celery_current_id.get()
-        record.celery_current_id = cid[: self.uuid_length] if cid else cid
+        record.celery_current_id = _trim_string(cid, self.uuid_length)
         return True

--- a/tests/test_log_filter.py
+++ b/tests/test_log_filter.py
@@ -10,7 +10,8 @@ from asgi_correlation_id.context import celery_current_id, celery_parent_id, cor
 @pytest.fixture()
 def cid():
     """Set and return a correlation ID"""
-    correlation_id.set(cid := uuid4().hex)
+    cid = uuid4().hex
+    correlation_id.set(cid)
     return cid
 
 
@@ -81,7 +82,8 @@ def test_celery_filter_truncates_current_id_correctly(cid: str, log_record: LogR
     Otherwise, the id should be truncated to the specified length.
     """
     filter_ = CeleryTracingIdsFilter(uuid_length=uuid_length)
-    celery_current_id.set(celery_id := str(uuid4()))
+    celery_id = str(uuid4())
+    celery_current_id.set(celery_id)
 
     assert not hasattr(log_record, 'celery_current_id')
     filter_.filter(log_record)
@@ -94,7 +96,8 @@ def test_celery_filter_maintains_current_behavior(cid: str, log_record: LogRecor
     Since the default values of CeleryTracingIdsFilter are being changed,
     the new default values should also not trim a hex uuid.
     """
-    celery_current_id.set(celery_id := uuid4().hex)
+    celery_id = uuid4().hex
+    celery_current_id.set(celery_id)
     new_filter = CeleryTracingIdsFilter()
 
     assert not hasattr(log_record, 'celery_current_id')

--- a/tests/test_log_filter.py
+++ b/tests/test_log_filter.py
@@ -65,3 +65,50 @@ def test_celery_filter_adds_current_id(cid, log_record):
     assert not hasattr(log_record, 'celery_current_id')
     filter_.filter(log_record)
     assert log_record.celery_current_id == 'b'
+
+
+def test_celery_filter_does_not_truncate_current_id(cid, log_record):
+    filter_ = CeleryTracingIdsFilter()
+    celery_id: str = str(uuid4())
+    celery_current_id.set(celery_id)
+
+    assert not hasattr(log_record, 'celery_current_id')
+    filter_.filter(log_record)
+    assert log_record.celery_current_id == celery_id
+
+
+def test_celery_filter_maintains_current_behavior(cid, log_record):
+    """Maintain default behavior with signature change
+
+    Since the default values of CeleryTracingIdsFilter are being changed,
+    the new default values should also not trim a hex uuid.
+    """
+    celery_id: str = uuid4().hex
+    celery_current_id.set(celery_id)
+
+    new_filter = CeleryTracingIdsFilter()
+
+    assert not hasattr(log_record, 'celery_current_id')
+    new_filter.filter(log_record)
+    assert log_record.celery_current_id == celery_id
+    new_filter_record_id = log_record.celery_current_id
+
+    del log_record.celery_current_id
+
+    original_filter = CeleryTracingIdsFilter(uuid_length=32)
+    assert not hasattr(log_record, 'celery_current_id')
+    original_filter.filter(log_record)
+    assert log_record.celery_current_id == celery_id
+    original_filter_record_id = log_record.celery_current_id
+
+    assert original_filter_record_id == new_filter_record_id
+
+
+def test_celery_filter_does_truncates_current_id(cid, log_record):
+    filter_ = CeleryTracingIdsFilter(uuid_length=16)
+    celery_id: str = uuid4().hex
+    celery_current_id.set(celery_id)
+
+    assert not hasattr(log_record, 'celery_current_id')
+    filter_.filter(log_record)
+    assert log_record.celery_current_id == celery_id[:16]

--- a/tests/test_log_filter.py
+++ b/tests/test_log_filter.py
@@ -10,16 +10,14 @@ from asgi_correlation_id.context import celery_current_id, celery_parent_id, cor
 @pytest.fixture()
 def cid():
     """Set and return a correlation ID"""
-    cid = uuid4().hex
-    correlation_id.set(cid)
+    correlation_id.set(cid := uuid4().hex)
     return cid
 
 
 @pytest.fixture()
 def log_record():
     """Create and return an INFO-level log record"""
-    record = LogRecord(name='', level=INFO, pathname='', lineno=0, msg='Hello, world!', args=(), exc_info=None)
-    return record
+    return LogRecord(name='', level=INFO, pathname='', lineno=0, msg='Hello, world!', args=(), exc_info=None)
 
 
 def test_filter_has_uuid_length_attributes():
@@ -27,7 +25,7 @@ def test_filter_has_uuid_length_attributes():
     assert filter_.uuid_length == 8
 
 
-def test_filter_adds_correlation_id(cid, log_record):
+def test_filter_adds_correlation_id(cid: str, log_record: LogRecord):
     filter_ = CorrelationIdFilter()
 
     assert not hasattr(log_record, 'correlation_id')
@@ -35,7 +33,7 @@ def test_filter_adds_correlation_id(cid, log_record):
     assert log_record.correlation_id == cid
 
 
-def test_filter_truncates_correlation_id(cid, log_record):
+def test_filter_truncates_correlation_id(cid: str, log_record: LogRecord):
     filter_ = CorrelationIdFilter(uuid_length=8)
 
     assert not hasattr(log_record, 'correlation_id')
@@ -49,7 +47,7 @@ def test_celery_filter_has_uuid_length_attributes():
     assert filter_.uuid_length == 8
 
 
-def test_celery_filter_adds_parent_id(cid, log_record):
+def test_celery_filter_adds_parent_id(cid: str, log_record: LogRecord):
     filter_ = CeleryTracingIdsFilter()
     celery_parent_id.set('a')
 
@@ -58,7 +56,7 @@ def test_celery_filter_adds_parent_id(cid, log_record):
     assert log_record.celery_parent_id == 'a'
 
 
-def test_celery_filter_adds_current_id(cid, log_record):
+def test_celery_filter_adds_current_id(cid: str, log_record: LogRecord):
     filter_ = CeleryTracingIdsFilter()
     celery_current_id.set('b')
 
@@ -67,25 +65,36 @@ def test_celery_filter_adds_current_id(cid, log_record):
     assert log_record.celery_current_id == 'b'
 
 
-def test_celery_filter_does_not_truncate_current_id(cid, log_record):
-    filter_ = CeleryTracingIdsFilter()
-    celery_id: str = str(uuid4())
-    celery_current_id.set(celery_id)
+@pytest.mark.parametrize(
+    ('uuid_length', 'expected'),
+    [
+        (6, 6),
+        (16, 16),
+        (None, 36),
+        (38, 36),
+    ],
+)
+def test_celery_filter_truncates_current_id_correctly(cid: str, log_record: LogRecord, uuid_length, expected):
+    """
+    If uuid is unspecified, the default should be 36.
+
+    Otherwise, the id should be truncated to the specified length.
+    """
+    filter_ = CeleryTracingIdsFilter(uuid_length=uuid_length)
+    celery_current_id.set(celery_id := str(uuid4()))
 
     assert not hasattr(log_record, 'celery_current_id')
     filter_.filter(log_record)
-    assert log_record.celery_current_id == celery_id
+    assert log_record.celery_current_id == celery_id[:expected]
 
 
-def test_celery_filter_maintains_current_behavior(cid, log_record):
+def test_celery_filter_maintains_current_behavior(cid: str, log_record: LogRecord):
     """Maintain default behavior with signature change
 
     Since the default values of CeleryTracingIdsFilter are being changed,
     the new default values should also not trim a hex uuid.
     """
-    celery_id: str = uuid4().hex
-    celery_current_id.set(celery_id)
-
+    celery_current_id.set(celery_id := uuid4().hex)
     new_filter = CeleryTracingIdsFilter()
 
     assert not hasattr(log_record, 'celery_current_id')
@@ -102,13 +111,3 @@ def test_celery_filter_maintains_current_behavior(cid, log_record):
     original_filter_record_id = log_record.celery_current_id
 
     assert original_filter_record_id == new_filter_record_id
-
-
-def test_celery_filter_does_truncates_current_id(cid, log_record):
-    filter_ = CeleryTracingIdsFilter(uuid_length=16)
-    celery_id: str = uuid4().hex
-    celery_current_id.set(celery_id)
-
-    assert not hasattr(log_record, 'celery_current_id')
-    filter_.filter(log_record)
-    assert log_record.celery_current_id == celery_id[:16]


### PR DESCRIPTION
Refer to #50 

Please review and I can address any requested changes :)

Added customizable generator options to celery extension to better match capabilities of the correlation id middleware
* Added optional "header_key" param to asgi_correlation_id.extensions.celery.load_correlation_id
* Added optional "generator" param to asgi_correlation_id.extensions.celery.load_correlation_id
* Added optional "generator" param to asgi_correlation_id.extensions.celery.load_celery_current_and_parent_ids

