### PR TITLE
Remove Access-Control-Expose-Headers response header

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ Configurable middleware arguments include:
 
 ## Exception handling
 
-By default, the `X-Request-ID` and `Access-Control-Expose-Headers` response headers will be included in all
-responses from the server, *except* in the case of unhandled server errors. If you wish to include request IDs in the
-case of a `500` error you can add a custom exception handler.
+By default, the `X-Request-ID` response header will be included in all responses from the server, *except* in the case
+of unhandled server errors. If you wish to include request IDs in the case of a `500` error you can add a custom
+exception handler.
 
 Here are some simple examples to help you get started. See each framework's documentation for more info.
 
@@ -220,10 +220,7 @@ async def custom_exception_handler(request: Request, exc: Exception) -> PlainTex
     return PlainTextResponse(
         "Internal Server Error",
         status_code=500,
-        headers={
-            'X-Request-ID': correlation_id.get() or "",
-            'Access-Control-Expose-Headers': 'X-Request-ID'
-        }
+        headers={'X-Request-ID': correlation_id.get() or ""}
     )
 
 
@@ -253,10 +250,7 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
         HTTPException(
             500,
             'Internal server error',
-            headers={
-                'X-Request-ID': correlation_id.get() or "",
-                'Access-Control-Expose-Headers': 'X-Request-ID'
-            }
+            headers={'X-Request-ID': correlation_id.get() or ""}
         ))
 ```
 

--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ middleware = [
         CORSMiddleware,
         allow_origins=['*'],
         allow_methods=['*'],
-        allow_headers=['X-Request-ID'],
-        expose_headers=['X-Requested-With', 'X-Request-ID']
+        allow_headers=['X-Requested-With', 'X-Request-ID'],
+        expose_headers=['X-Request-ID']
     )
 ]
 
@@ -243,8 +243,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=['*'],
     allow_methods=['*'],
-    allow_headers=['X-Request-ID'],
-    expose_headers=['X-Requested-With', 'X-Request-ID']
+    allow_headers=['X-Requested-With', 'X-Request-ID'],
+    expose_headers=['X-Request-ID']
 )
 ```
 

--- a/asgi_correlation_id/middleware.py
+++ b/asgi_correlation_id/middleware.py
@@ -80,7 +80,6 @@ class CorrelationIdMiddleware:
             if message['type'] == 'http.response.start' and correlation_id.get():
                 headers = MutableHeaders(scope=message)
                 headers.append(self.header_name, correlation_id.get())
-                headers.append('Access-Control-Expose-Headers', self.header_name)
 
             await send(message)
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -30,9 +30,7 @@ pytestmark = pytest.mark.asyncio
 @pytest.mark.parametrize('app', [default_app, no_validator_or_transformer_app, generator_app])
 async def test_returned_response_headers(app):
     """
-    We expect:
-     - our request id header to be returned back to us
-     - the request id header name to be returned in access-control-expose-headers
+    We expect our request id header to be returned back to us.
     """
 
     @app.get('/test', status_code=200)
@@ -44,18 +42,15 @@ async def test_returned_response_headers(app):
         # Check we get the right headers back
         correlation_id = uuid4().hex
         response = await client.get('test', headers={'X-Request-ID': correlation_id})
-        assert response.headers['access-control-expose-headers'] == 'X-Request-ID'
         assert response.headers['X-Request-ID'] == correlation_id
 
         # And do it one more time, jic
         second_correlation_id = uuid4().hex
         second_response = await client.get('test', headers={'X-Request-ID': second_correlation_id})
-        assert second_response.headers['access-control-expose-headers'] == 'X-Request-ID'
         assert second_response.headers['X-Request-ID'] == second_correlation_id
 
         # Then try without specifying a request id
         third_response = await client.get('test')
-        assert third_response.headers['access-control-expose-headers'] == 'X-Request-ID'
         assert third_response.headers['X-Request-ID'] not in [correlation_id, second_correlation_id]
 
 
@@ -132,22 +127,6 @@ async def test_websocket_request(caplog, app):
     with client.websocket_connect('/ws') as ws:
         ws.receive_json()
         assert caplog.messages == []
-
-
-@pytest.mark.parametrize('app', apps)
-async def test_access_control_expose_headers(caplog, app):
-    """
-    The middleware should add the correlation ID header name to exposed headers.
-    The middleware should not overwrite other values, but should append to it.
-    """
-
-    @app.get('/access-control-expose-headers')
-    async def access_control_view() -> Response:
-        return Response(status_code=204, headers={'Access-Control-Expose-Headers': 'test1, test2'})
-
-    async with AsyncClient(app=app, base_url='http://test') as client:
-        response = await client.get('access-control-expose-headers')
-        assert response.headers['Access-Control-Expose-Headers'] == 'test1, test2, X-Request-ID'
 
 
 @pytest.mark.parametrize('app', apps)


### PR DESCRIPTION
As discussed in https://github.com/snok/asgi-correlation-id/discussions/66, handling CORS should better be left to a specialized middleware.