### PR TITLE
breaking: Change the default value of `update_request_header`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The middleware can be configured in a few ways, but there are no required argume
 app.add_middleware(
     CorrelationIdMiddleware,
     header_name='X-Request-ID',
-    update_request_header=False,
+    update_request_header=True,
     generator=lambda: uuid4().hex,
     validator=is_valid_uuid4,
     transformer=lambda a: a,
@@ -167,7 +167,7 @@ Configurable middleware arguments include:
 **update_request_header**
 
 - Type: `bool`
-- Default: `False`
+- Default: `True`
 - Description: Whether to update incoming request's header value with the generated correlation ID. This is to support
   use cases where it's relied on the presence of the request header (like various tracing middlewares).
 

--- a/asgi_correlation_id/middleware.py
+++ b/asgi_correlation_id/middleware.py
@@ -31,7 +31,7 @@ FAILED_VALIDATION_MESSAGE = 'Generated new request ID (%s), since request header
 class CorrelationIdMiddleware:
     app: 'ASGIApp'
     header_name: str = 'X-Request-ID'
-    update_request_header: bool = False
+    update_request_header: bool = True
 
     # ID-generating callable
     generator: Callable[[], str] = field(default=lambda: uuid4().hex)


### PR DESCRIPTION
Switches the default value of `update_request_header` to `True`, since we are planning to bump major version and this seems like a saner default.