### PR TITLE
Use new header value in failed validation warning

### DIFF
--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -106,8 +106,9 @@ async def test_non_uuid_header(client, caplog, value, app):
 
     async with AsyncClient(app=app, base_url='http://test') as client:
         response = await client.get('test', headers={'X-Request-ID': value})
-        assert response.headers['X-Request-ID'] != value
-        assert caplog.messages[0] == FAILED_VALIDATION_MESSAGE.replace('%s', value)
+        new_value = response.headers['X-Request-ID']
+        assert new_value != value
+        assert caplog.messages[0] == FAILED_VALIDATION_MESSAGE.replace('%s', new_value)
 
 
 @pytest.mark.parametrize('app', apps)


### PR DESCRIPTION
We should use the newly generated header value in the failed validation warning message as using the original header value might be a security risk. See the discussion here – https://github.com/snok/asgi-correlation-id/discussions/69.