### PR TITLE
Add packaging, used in sentry integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.8"
 starlette = ">=0.18"
+packaging = "*"
 celery = { version = '*', optional = true }
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
hey folks,
the latest update in the sentry integration introduces a dependency to `packaging` which is missing in the poetry config

using this we get 
```
ModuleNotFoundError
No module named 'packaging'
```
on asgi_correlation_id/extensions/sentry.py:26

thanks in advance
nasko